### PR TITLE
Honor system CFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(shell mkdir -p $(dir $(OBJS)) >/dev/null)
 $(shell mkdir -p $(dir $(DEPS)) >/dev/null)
 
 CC=gcc
-CFLAGS=-Wall -O3 -std=gnu99
+CFLAGS+=-Wall -O3 -std=gnu99
 LDLIBS=-lqpid-proton -lpthread
 LDFLAGS=
 


### PR DESCRIPTION
While building the sg-bridge RPM I ran into a problem where a debuginfo version of the package could not be built, and I found some documentation [1] suggesting that it may be because the build system CFLAGS are not being honored, and that may have other important (security) implications.

I'm not 100% sure this will fix the problem, or that it is the total effect that we want, but I think it's an improvement?

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Debuginfo/

Here are how the flags play out with this patch:

```
[csibbitt@laptop sg-bridge (master) ]$ make
gcc -MT obj/amqp_rcv_th.o -MD -MP -MF obj/.deps/amqp_rcv_th.Td -Wall -O3 -std=gnu99  -c -o obj/amqp_rcv_th.o amqp_rcv_th.c

[csibbitt@laptop sg-bridge (master) ]$ make debug
gcc -MT obj/amqp_rcv_th.o -MD -MP -MF obj/.deps/amqp_rcv_th.Td -Wall -g  -c -o obj/amqp_rcv_th.o amqp_rcv_th.c

[csibbitt@laptop sg-bridge (master) ]$ export CFLAGS=-funroll-loops
[csibbitt@laptop sg-bridge (master) ]$ make
gcc -MT obj/bridge.o -MD -MP -MF obj/.deps/bridge.Td -funroll-loops -Wall -O3 -std=gnu99  -c -o obj/bridge.o bridge.c

[csibbitt@laptop sg-bridge (master) ]$ make debug
gcc -MT obj/amqp_rcv_th.o -MD -MP -MF obj/.deps/amqp_rcv_th.Td -Wall -g  -c -o obj/amqp_rcv_th.o amqp_rcv_th.c
```