### PR TITLE
Build tweaks for RPM distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(shell mkdir -p $(dir $(DEPS)) >/dev/null)
 CC=gcc
 CFLAGS+=-Wall -O3 -std=gnu99
 LDLIBS=-lqpid-proton -lpthread
-LDFLAGS=
+LDFLAGS+=
 
 DEPFLAGS = -MT $@ -MD -MP -MF $(DEPDIR)/$*.Td
 

--- a/bridge.c
+++ b/bridge.c
@@ -93,7 +93,7 @@ static void usage(char *program) {
     fprintf(stdout, "args:\n");
     for (int i = 0; i < (sizeof(option_info) / sizeof(option_info[0])); i++) {
         char help_buffer[200];
-        sprintf(help_buffer, option_info[i].arg_help, option_info[i].arg_default);
+        snprintf(help_buffer, sizeof(help_buffer), option_info[i].arg_help, option_info[i].arg_default);
         fprintf(stdout, "  --%-*s %-*s %s\n", widths[0], option_info[i].lopt.name, widths[1], option_info[i].arg_example, help_buffer);
     }
 }
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
 
     setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
 
-    sprintf(cid_buf, DEFAULT_CID, rand() % 1024);
+    snprintf(cid_buf, sizeof(cid_buf), DEFAULT_CID, rand() % 1024);
 
     app.stat_period = 0;        /* disabled */
     app.container_id = cid_buf; /* Should be unique */
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
                 app.domain = AF_INET;
                 break;
             case ARG_CID:
-                sprintf(cid_buf, optarg);
+                strncpy(cid_buf, optarg, sizeof(cid_buf) - 1);
                 break;
             case ARG_COUNT:
                 app.message_count = atoi(optarg);

--- a/utils.c
+++ b/utils.c
@@ -25,10 +25,10 @@ void time_diff(struct timespec t1, struct timespec t2, struct timespec *diff) {
 
 }
 
-char *time_sprintf(char *buf, struct timespec t1) {
+char *time_snprintf(char *buf, size_t n, struct timespec t1) {
 	double pct = (t1.tv_sec * 1000000000.0) + t1.tv_nsec / 1000000000.0;
 
-	sprintf(buf, "%f", pct);
+	snprintf(buf, n, "%f", pct);
 
 	return buf;
 }

--- a/utils.h
+++ b/utils.h
@@ -4,6 +4,6 @@
 #include <time.h>
 
 void time_diff(struct timespec t1, struct timespec t2, struct timespec *diff);
-char *time_sprintf(char *buf, struct timespec t1);
+char *time_snprintf(char *buf, size_t n, struct timespec t1);
 
 #endif


### PR DESCRIPTION
RPM builds on Fedora and RHEL8 pass in pedantic CFLAGS and LDFLAGS. These patch ensure:

- compilation still works when that happens
- ensures that both CFLAGS and LDFLAGS are honored from within the Makefile

The RHEL8 annocheck can be run on the resulting bridge binary with no errors.

**Note** I did change time_sprintf -> time_snprintf. However, this function seems to not be used anywhere in the code nor exposed via any libraries.