### PR TITLE
Add --amqp_block program argument

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -50,6 +50,7 @@ enum program_args {
     ARG_RING_BUFFER_COUNT,
     ARG_RING_BUFFER_SIZE,
     ARG_VERBOSE,
+    ARG_AMQP_BLOCK,
     ARG_HELP
 };
 
@@ -101,6 +102,10 @@ struct option_info option_info[] = {
      "",
      "Print extra info, multiple instance increase verbosity.",
      ""},
+    {{"amqp_block", no_argument, 0, ARG_AMQP_BLOCK},
+     "",
+     "Stop reading incoming messages if the buffer is full (%s)",
+     DEFAULT_AMQP_BLOCK},
     {{"help", no_argument, 0, ARG_HELP}, "", "Print help.", ""}};
 
 static void usage(char *program) {
@@ -191,6 +196,7 @@ int main(int argc, char **argv) {
     app.peer_port = DEFAULT_INET_PORT;
     app.ring_buffer_size = atoi(DEFAULT_RING_BUFFER_SIZE);
     app.ring_buffer_count = atoi(DEFAULT_RING_BUFFER_COUNT);
+    app.amqp_block = false; /* disabled */
 
     int num_args = sizeof(option_info) / sizeof(struct option_info);
     struct option *longopts = malloc(sizeof(struct option) * num_args);
@@ -251,6 +257,9 @@ int main(int argc, char **argv) {
         case 'v':
             app.verbose++;
             break;
+        case ARG_AMQP_BLOCK:
+            app.amqp_block = true;
+            break;
         case 'h':
         case ARG_HELP:
             usage(argv[0]);
@@ -285,7 +294,7 @@ int main(int argc, char **argv) {
         printf("Standalone mode\n");
     }
 
-    app.rbin = rb_alloc(app.ring_buffer_count, app.ring_buffer_size);
+    app.rbin = rb_alloc(app.ring_buffer_count, app.ring_buffer_size, app.amqp_block);
 
     app.amqp_rcv_th_running = true;
     pthread_create(&app.amqp_rcv_th, NULL, amqp_rcv_th, (void *)&app);

--- a/bridge.c
+++ b/bridge.c
@@ -294,7 +294,8 @@ int main(int argc, char **argv) {
         printf("Standalone mode\n");
     }
 
-    app.rbin = rb_alloc(app.ring_buffer_count, app.ring_buffer_size, app.amqp_block);
+    app.rbin =
+        rb_alloc(app.ring_buffer_count, app.ring_buffer_size, app.amqp_block);
 
     app.amqp_rcv_th_running = true;
     pthread_create(&app.amqp_rcv_th, NULL, amqp_rcv_th, (void *)&app);

--- a/bridge.h
+++ b/bridge.h
@@ -23,6 +23,7 @@
 #define DEFAULT_STOP_COUNT "0"
 #define DEFAULT_RING_BUFFER_COUNT "5000"
 #define DEFAULT_RING_BUFFER_SIZE "2048"
+#define DEFAULT_AMQP_BLOCK "false"
 
 #define AMQP_URL_REGEX                                                         \
     "^amqp://(([a-z]+)(:([a-z]+))*@)*([a-zA-Z_0-9.-]+)(:([0-9]+))*(.+)$"
@@ -72,6 +73,7 @@ typedef struct {
     long amqp_partial;
     long amqp_total_batches;
     long amqp_link_credit;
+    bool amqp_block;
 
     /* Ring buffer stats */
     int max_q_depth;

--- a/rb.c
+++ b/rb.c
@@ -54,9 +54,9 @@ rb_rwbytes_t *rb_alloc(int count, int buf_size, bool block_producer) {
     pthread_cond_init(&rb->rb_ready, NULL);
     pthread_mutex_init(&rb->rb_mutex, NULL);
 
-	if (rb->block_producer) {
-		pthread_cond_init(&rb->rb_free, NULL);
-	}
+    if (rb->block_producer) {
+        pthread_cond_init(&rb->rb_free, NULL);
+    }
 
     return rb;
 }
@@ -142,11 +142,11 @@ pn_rwbytes_t *rb_get(rb_rwbytes_t *rb) {
 
     rb->tail = next;
 
-	if (rb->block_producer) {
-		pthread_mutex_lock(&rb->rb_mutex);
-		pthread_cond_broadcast(&rb->rb_free);
-		pthread_mutex_unlock(&rb->rb_mutex);
-	}
+    if (rb->block_producer) {
+        pthread_mutex_lock(&rb->rb_mutex);
+        pthread_cond_broadcast(&rb->rb_free);
+        pthread_mutex_unlock(&rb->rb_mutex);
+    }
 
     rb->processed++;
 

--- a/rb.h
+++ b/rb.h
@@ -12,12 +12,14 @@ typedef struct {
 
     int count;
     int buf_size;
+    bool block_producer;
 
     volatile int head;
     volatile int tail;
 
     pthread_mutex_t rb_mutex;
     pthread_cond_t rb_ready;
+    pthread_cond_t rb_free;
 
     // stats
     //
@@ -32,7 +34,7 @@ typedef struct {
 
 } rb_rwbytes_t;
 
-extern rb_rwbytes_t *rb_alloc(int count, int buf_size);
+extern rb_rwbytes_t *rb_alloc(int count, int buf_size, bool block_producer);
 
 extern pn_rwbytes_t *rb_get_head(rb_rwbytes_t *rb);
 


### PR DESCRIPTION
This PR adds --amqp_block (disabled by default) program argument, which prevents sg-bridge from dropping amqp messages when the ring buffer is full. This might be useful for debugging (together with --block sg-bridge should deliver everything, that appears on amqp).

Please check if I'm using the pthread condition correctly, it's my first time I'm working with these.