### PR TITLE
Use link credits for reliable amqp transport

### DIFF
--- a/bridge.h
+++ b/bridge.h
@@ -23,6 +23,7 @@
 #define DEFAULT_STOP_COUNT "0"
 #define DEFAULT_RING_BUFFER_COUNT "5000"
 #define DEFAULT_RING_BUFFER_SIZE "2048"
+#define DEFAULT_AMQP_BLOCK "false"
 
 #define AMQP_URL_REGEX                                                         \
     "^(amqps*)://(([a-z]+)(:([a-z]+))*@)*([a-zA-Z_0-9.-]+)(:([0-9]+))*(.+)$"
@@ -71,6 +72,7 @@ typedef struct {
     volatile long amqp_partial;
     volatile long amqp_total_batches;
     volatile long amqp_link_credit;
+    volatile bool amqp_block;
 
     /* Ring buffer stats */
     volatile long link_credit;

--- a/rb.h
+++ b/rb.h
@@ -12,12 +12,14 @@ typedef struct {
 
     int count;
     int buf_size;
+    bool wake_producer;
 
     volatile int head;
     volatile int tail;
 
     pthread_mutex_t rb_mutex;
     pthread_cond_t rb_ready;
+    pthread_cond_t rb_free;
 
     // stats
     //
@@ -32,7 +34,7 @@ typedef struct {
 
 } rb_rwbytes_t;
 
-extern rb_rwbytes_t *rb_alloc(int count, int buf_size);
+extern rb_rwbytes_t *rb_alloc(int count, int buf_size, bool wake_producer);
 
 extern pn_rwbytes_t *rb_get_head(rb_rwbytes_t *rb);
 


### PR DESCRIPTION
This PR is a reimplementation of #19 using link credits.

Summary of changes:

- Changed rb_free_size() to report the free size correctly (I checked where in the code this is used and it shouldn't cause problems)
- Added --amqp_block argument
- Changed the computation of link credits

### Differences in link the link credits computation:
Without the --amqp_block argument (for metrics) the link credit is always ring buffer free size + 1, so in the worst scenario (the buffer is full) the link credit is set to 1 and the bridge is always receiving amqp messages. (I just noticed, that before the link credit was 2 in that situation, does that matter? Should I change it to rb_free_size + 2?).

With the --amqp_block argument the link credit is always the ring buffer free size, so when the ring buffer is full, the link credit doesn't get raised (amqp clients stop sending messages) and the receiving thread is blocked. When the sending thread reads something from the buffer, it frees a space inside the buffer and unblocks the receiving thread, which raises the link credit to reflect the current free space inside the ring buffer.