### PR TITLE
Change the computation of the link_credit stat (#22)

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -306,6 +306,7 @@ int main(int argc, char **argv) {
     long last_overrun = 0;
     long last_out = 0;
     long last_sock_overrun = 0;
+    long last_link_credit = 0;
 
     long sleep_count = 1;
 
@@ -313,13 +314,14 @@ int main(int argc, char **argv) {
         sleep(1);
         if (sleep_count == app.stat_period) {
             printf("in: %ld(%ld), amqp_overrun: %ld(%ld), out: %ld(%ld), "
-                   "sock_overrun: %ld(%ld), link_credit: %f\n",
+                   "sock_overrun: %ld(%ld), link_credit_average: %f\n",
                    app.amqp_received, app.amqp_received - last_amqp_received,
                    app.rbin->overruns, app.rbin->overruns - last_overrun,
                    app.sock_sent, app.sock_sent - last_out,
                    app.sock_would_block,
                    app.sock_would_block - last_sock_overrun,
-                   app.link_credit / (float)app.amqp_received);
+                   (app.link_credit - last_link_credit) /
+                       (float)(app.amqp_received - last_amqp_received));
 
             sleep_count = 1;
         }
@@ -328,6 +330,7 @@ int main(int argc, char **argv) {
         last_overrun = app.rbin->overruns;
         last_out = app.sock_sent;
         last_sock_overrun = app.sock_would_block;
+        last_link_credit = app.link_credit;
 
         if (app.socket_snd_th_running == 0) {
             pthread_join(app.socket_snd_th, NULL);


### PR DESCRIPTION
* Change the computation of the link_credit stat

* Committing clang-format changes

* Change link credit stat computation to average.

* Committing clang-format changes

* Fix race condition in link credit stat computation

* Committing clang-format changes

Co-authored-by: InfraWatch CI <robot@infra.watch>
Cherry picked from commit 912aaf892e6231bdd7af26fff1c01be966b0748a
