### PR TITLE
Fix and test Dockerfile builds

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,3 +28,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  docker-build-check:
+    name: Check Dockerfile results in successful build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Check build of Dockerfile is successful
+        run: docker build -t sg-bridge:check-build -f build/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 MAJOR?=0
 MINOR?=1
- 
+
 VERSION=$(MAJOR).$(MINOR)
 
 BIN := bridge
@@ -22,7 +22,7 @@ $(shell mkdir -p $(dir $(OBJS)) >/dev/null)
 $(shell mkdir -p $(dir $(DEPS)) >/dev/null)
 
 CC=gcc
-CFLAGS+=-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection
+CFLAGS+=-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection
 LDLIBS=-lqpid-proton -lpthread
 LDFLAGS+=-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,8 +4,11 @@ FROM registry.access.redhat.com/ubi8 AS builder
 # dependencies for qpid-proton-c
 COPY build/repos/opstools.repo /etc/yum.repos.d/opstools.repo
 
+# redhat-rpm-config is required to provide hardening compiling instructions
+# (such as /usr/lib/rpm/redhat/redhat-hardened-cc1) even though we're not
+# building RPMs here
 RUN dnf install qpid-proton-c-devel --setopt=tsflags=nodocs -y && \
-        dnf install gcc make -y && \
+        dnf install gcc make redhat-rpm-config -y && \
         dnf clean all
 
 ENV D=/home/bridge


### PR DESCRIPTION
When making fixes in #29 related to lint checks, a local build wasn't
done against the Dockerfile, which has a different base image from that
used by build_checks for lint verification. The result of that was that
building sg-bridge with the Dockerfile failed on gcc compiling due to
hardening instructions not being available.

This commit does the following:

* adds the RPM dependency to the build layer of Dockerfile to install
  hardening instructions for gcc
* changes the default -march CFLAG to be x86-64 instead of x86-64-v2
  which fails in ubi8
* updates the GHA to add a build check against the Dockerfile and not
  just run build_checks.sh for future validation

Found by csibbitt and noted in chat.

Resolves #30

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
