### PR TITLE
[zuul] Use the stf-crc-jobs project template

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,7 +1,5 @@
 ---
 - project:
     name: infrawatch/sg-bridge
-    github-check:
-      jobs:
-        - stf-crc-latest-nightly_bundles
-        - stf-crc-latest-local_build
+    templates:
+      - stf-crc-jobs


### PR DESCRIPTION
Instead of updating the .zuul.yaml file everytime
infrawatch/service-telemetry-operator adds a new job, the project-template can be updated in STO, which will propogate the change to the project and avoid leaving gaps in testing.

Depends-On: https://github.com/infrawatch/service-telemetry-operator/pull/514