### PR TITLE
Bump actions checkout to v4

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
       - name: Run clang-format-lint
         uses: DoozyX/clang-format-lint-action@v0.11
         with:
@@ -34,6 +34,6 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
       - name: Check build of Dockerfile is successful
         run: docker build -t sg-bridge:check-build -f build/Dockerfile .


### PR DESCRIPTION
Bump actions checkout to v4 since Node.js 16 actions are deprecated. We need to update to Node.js 20, which is included in actions/checkout@v4.