### PR TITLE
Update repo info for opstools

### DIFF
--- a/build/repos/opstools.repo
+++ b/build/repos/opstools.repo
@@ -11,8 +11,8 @@ enabled=0
 
 [centos-opstools]
 name=CentOS-OpsTools - collectd
-mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$releasever-stream&repo=opstools-collectd-5
-#baseurl=http://mirror.centos.org/$contentdir/$releasever-stream/opstools/$basearch/collectd-5/
+#mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$releasever-stream&repo=opstools-collectd-5
+baseurl=http://vault.centos.org/$releasever-stream/opstools/$basearch/collectd-5/
 gpgcheck=0
 enabled=1
 skip_if_unavailable=1


### PR DESCRIPTION
Centos8s went EOL on 31.05.2024 so the packages have been moved to centos vault mirror the repo config we use needs to be updated

Should depend on https://github.com/infrawatch/sg-core/pull/135 but we can't have a dependency loop